### PR TITLE
add default mount action + small cleanup

### DIFF
--- a/Module.cs
+++ b/Module.cs
@@ -32,7 +32,7 @@ namespace Manlaan.Mounts
         public static int[] _mountOrder = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         public static string[] _mountDisplay = new string[] { "Transparent Corner", "Solid Corner", "Transparent Manual", "Solid Manual", "Solid Manual Text" };
         public static string[] _mountOrientation = new string[] { "Horizontal", "Vertical" };
-
+        private SettingEntry<KeyBinding> InputQueuingKeybindSetting = null;
         public static string[] _defaultMountChoices = new string[] { "Disabled", "Raptor", "Springer", "Skimmer", "Jackal", "Griffon", "Roller Beetle", "Skyscale", "Warclaw" };
         Dictionary<string, Action> defaultMountChoicesToActions;
         Gw2Sharp.Models.MapType[] warclawOnlyMaps = {
@@ -90,6 +90,7 @@ namespace Manlaan.Mounts
         protected override void Initialize()
         {
             InitializeDefaultMountActions();
+            GameService.Gw2Mumble.PlayerCharacter.IsInCombatChanged += (sender, e) => HandleCombatChange(sender, e);
         }
 
         private void InitializeDefaultMountActions()
@@ -611,8 +612,23 @@ namespace Manlaan.Mounts
             defaultMountChoicesToActions[_settingDefaultMountChoice.Value]();
         }
 
+        private void HandleCombatChange(object sender, ValueEventArgs<bool> e)
+        {
+            if(!e.Value)
+            {
+                DoHotKey(InputQueuingKeybindSetting);
+                InputQueuingKeybindSetting = null;
+            }
+        }
+
         protected void DoHotKey(SettingEntry<KeyBinding> setting)
         {
+            if (GameService.Gw2Mumble.PlayerCharacter.IsInCombat)
+            {
+                InputQueuingKeybindSetting = setting;
+                return;
+            }
+
             if (setting.Value.ModifierKeys != ModifierKeys.None)
             {
                 if (setting.Value.ModifierKeys.HasFlag(ModifierKeys.Alt))

--- a/Module.cs
+++ b/Module.cs
@@ -12,6 +12,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Blish_HUD.Graphics.UI;
+using System.Collections.Generic;
 
 namespace Manlaan.Mounts
 {
@@ -32,6 +33,19 @@ namespace Manlaan.Mounts
         public static string[] _mountDisplay = new string[] { "Transparent Corner", "Solid Corner", "Transparent Manual", "Solid Manual", "Solid Manual Text" };
         public static string[] _mountOrientation = new string[] { "Horizontal", "Vertical" };
 
+        public static string[] _defaultMountChoices = new string[] { "Disabled", "Raptor", "Springer", "Skimmer", "Jackal", "Griffon", "Roller Beetle", "Skyscale", "Warclaw" };
+        Dictionary<string, Action> defaultMountChoicesToActions;
+        Gw2Sharp.Models.MapType[] warclawOnlyMaps = {
+                Gw2Sharp.Models.MapType.RedBorderlands,
+                Gw2Sharp.Models.MapType.RedHome,
+                Gw2Sharp.Models.MapType.BlueBorderlands,
+                Gw2Sharp.Models.MapType.BlueHome,
+                Gw2Sharp.Models.MapType.GreenBorderlands,
+                Gw2Sharp.Models.MapType.GreenHome,
+                Gw2Sharp.Models.MapType.EternalBattlegrounds,
+                Gw2Sharp.Models.MapType.Center,
+            };
+
         public static SettingEntry<int> _settingGriffonOrder;
         public static SettingEntry<int> _settingJackalOrder;
         public static SettingEntry<int> _settingRaptorOrder;
@@ -40,6 +54,7 @@ namespace Manlaan.Mounts
         public static SettingEntry<int> _settingSkyscaleOrder;
         public static SettingEntry<int> _settingSpringerOrder;
         public static SettingEntry<int> _settingWarclawOrder;
+        public static SettingEntry<string> _settingDefaultMountChoice;
         public static SettingEntry<KeyBinding> _settingGriffonBinding;
         public static SettingEntry<KeyBinding> _settingJackalBinding;
         public static SettingEntry<KeyBinding> _settingRaptorBinding;
@@ -48,6 +63,7 @@ namespace Manlaan.Mounts
         public static SettingEntry<KeyBinding> _settingSkyscaleBinding;
         public static SettingEntry<KeyBinding> _settingSpringerBinding;
         public static SettingEntry<KeyBinding> _settingWarclawBinding;
+        public static SettingEntry<KeyBinding> _settingDefaultMountBinding;
         public static SettingEntry<string> _settingDisplay;
         public static SettingEntry<string> _settingOrientation;
         private SettingEntry<Point> _settingLoc;
@@ -73,6 +89,28 @@ namespace Manlaan.Mounts
 
         protected override void Initialize()
         {
+            InitializeDefaultMountActions();
+        }
+
+        private void InitializeDefaultMountActions()
+        {
+            defaultMountChoicesToActions = new Dictionary<string, Action>();
+            var defaultMountActions = new Action[]
+            {
+                () =>{ },
+                () =>{ DoHotKey(_settingRaptorBinding); },
+                () =>{ DoHotKey(_settingSpringerBinding); },
+                () =>{ DoHotKey(_settingSkimmerBinding); },
+                () =>{ DoHotKey(_settingJackalBinding); },
+                () =>{ DoHotKey(_settingGriffonBinding); },
+                () =>{ DoHotKey(_settingRollerBinding); },
+                () =>{ DoHotKey(_settingSkyscaleBinding); },
+                () =>{ DoHotKey(_settingWarclawBinding); }
+            };
+            for (int index = 0; index < defaultMountActions.Length; index++)
+            {
+                defaultMountChoicesToActions.Add(_defaultMountChoices[index], defaultMountActions[index]);
+            }
         }
 
         protected override void DefineSettings(SettingCollection settings)
@@ -85,6 +123,7 @@ namespace Manlaan.Mounts
             _settingRollerOrder = settings.DefineSetting("MountRollerOrder2", 6, "Roller Order", "");
             _settingWarclawOrder = settings.DefineSetting("MountWarclawOrder2", 7, "Warclaw Order", "");
             _settingSkyscaleOrder = settings.DefineSetting("MountSkyscaleOrder2", 8, "Skyscale Order", "");
+            _settingDefaultMountChoice = settings.DefineSetting("DefaultMountChoice", "Disabled", "Default Mount Choice", "");
 
             _settingRaptorBinding = settings.DefineSetting("MountRaptorBinding", new KeyBinding(Keys.None), "Raptor Binding", "");
             _settingSpringerBinding = settings.DefineSetting("MountSpringerBinding", new KeyBinding(Keys.None), "Springer Binding", "");
@@ -94,6 +133,7 @@ namespace Manlaan.Mounts
             _settingRollerBinding = settings.DefineSetting("MountRollerBinding", new KeyBinding(Keys.None), "Roller Binding", "");
             _settingWarclawBinding = settings.DefineSetting("MountWarclawBinding", new KeyBinding(Keys.None), "Warclaw Binding", "");
             _settingSkyscaleBinding = settings.DefineSetting("MountSkyscaleBinding", new KeyBinding(Keys.None), "Skyscale Binding", "");
+            _settingDefaultMountBinding = settings.DefineSetting("DefaultMountBinding", new KeyBinding(Keys.None), "Default Mount Binding", "");
 
             _settingDisplay = settings.DefineSetting("MountDisplay", "Transparent Corner", "Display Type", "");
             _settingOrientation = settings.DefineSetting("Orientation", "Horizontal", "Manual Orientation", "");
@@ -122,6 +162,9 @@ namespace Manlaan.Mounts
             _settingSkyscaleBinding.SettingChanged += UpdateSettings;
             _settingSpringerBinding.SettingChanged += UpdateSettings;
             _settingWarclawBinding.SettingChanged += UpdateSettings;
+            _settingDefaultMountBinding.SettingChanged += UpdateSettings;
+            _settingDefaultMountBinding.Value.Enabled = true;
+            _settingDefaultMountBinding.Value.Activated += delegate { DoDefaultMountAction(); };
 
             _settingDisplay.SettingChanged += UpdateSettings;
             _settingOrientation.SettingChanged += UpdateSettings;
@@ -151,16 +194,23 @@ namespace Manlaan.Mounts
 
         protected override void Update(GameTime gameTime)
         {
-            if (GameService.GameIntegration.Gw2Instance.IsInGame && !GameService.Gw2Mumble.UI.IsMapOpen) {
-                _mountPanel.Show();
-            } else {
-                _mountPanel.Hide(); 
-            }
-            if (_dragging) {
-                var nOffset = InputService.Input.Mouse.Position - _dragStart;
-                _mountPanel.Location += nOffset;
+            if(_mountPanel != null)
+            {
+                if (GameService.GameIntegration.Gw2Instance.IsInGame && !GameService.Gw2Mumble.UI.IsMapOpen)
+                {
+                    _mountPanel.Show();
+                }
+                else
+                {
+                    _mountPanel.Hide();
+                }
+                if (_dragging)
+                {
+                    var nOffset = InputService.Input.Mouse.Position - _dragStart;
+                    _mountPanel.Location += nOffset;
 
-                _dragStart = InputService.Input.Mouse.Position;
+                    _dragStart = InputService.Input.Mouse.Position;
+                }
             }
         }
 
@@ -195,6 +245,7 @@ namespace Manlaan.Mounts
             _settingSkyscaleBinding.SettingChanged -= UpdateSettings;
             _settingSpringerBinding.SettingChanged -= UpdateSettings;
             _settingWarclawBinding.SettingChanged -= UpdateSettings;
+            _settingDefaultMountBinding.SettingChanged -= UpdateSettings;
 
             _settingDisplay.SettingChanged -= UpdateSettings;
             _settingOrientation.SettingChanged -= UpdateSettings;
@@ -541,6 +592,25 @@ namespace Manlaan.Mounts
                     return ContentsManager.GetTexture(filename + "-text.png");
             }
         }
+
+
+        private void DoDefaultMountAction()
+        {
+            if (Array.Exists(warclawOnlyMaps, mapType => mapType == GameService.Gw2Mumble.CurrentMap.Type))
+            {
+                DoHotKey(_settingWarclawBinding);
+                return;
+            }
+
+            if (GameService.Gw2Mumble.PlayerCharacter.Position.Z <= 0)
+            {
+                DoHotKey(_settingSkimmerBinding);
+                return;
+            }
+
+            defaultMountChoicesToActions[_settingDefaultMountChoice.Value]();
+        }
+
         protected void DoHotKey(SettingEntry<KeyBinding> setting)
         {
             if (setting.Value.ModifierKeys != ModifierKeys.None)

--- a/Views/SettingsView.cs
+++ b/Views/SettingsView.cs
@@ -2,13 +2,14 @@
 using Microsoft.Xna.Framework;
 using Blish_HUD.Settings.UI.Views;
 using Blish_HUD.Graphics.UI;
+using System;
 
 namespace Manlaan.Mounts.Views
 {
     class SettingsView : View
     {
         protected override void Build(Container buildPanel) {
-            int labelWidth = 65;
+            int labelWidth = 100;
             int orderWidth = 80;
             int bindingWidth = 150;
 
@@ -91,9 +92,6 @@ namespace Manlaan.Mounts.Views
                 KeyBinding = Module._settingRaptorBinding.Value,
                 Location = new Point(settingRaptor_Select.Right + 5, settingRaptor_Label.Top - 1),
             };
-            settingRaptor_Keybind.BindingChanged += delegate {
-                Module._settingRaptorBinding.Value = settingRaptor_Keybind.KeyBinding;
-            };
 
             Label settingSpringer_Label = new Label() {
                 Location = new Point(0, settingRaptor_Label.Bottom + 6),
@@ -127,9 +125,6 @@ namespace Manlaan.Mounts.Views
                 Parent = mountsLeftPanel,
                 KeyBinding = Module._settingSpringerBinding.Value,
                 Location = new Point(settingSpringer_Select.Right + 5, settingSpringer_Label.Top - 1),
-            };
-            settingSpringer_Keybind.BindingChanged += delegate {
-                Module._settingSpringerBinding.Value = settingSpringer_Keybind.KeyBinding;
             };
 
             Label settingSkimmer_Label = new Label() {
@@ -165,9 +160,6 @@ namespace Manlaan.Mounts.Views
                 KeyBinding = Module._settingSkimmerBinding.Value,
                 Location = new Point(settingSkimmer_Select.Right + 5, settingSkimmer_Label.Top - 1),
             };
-            settingSkimmer_Keybind.BindingChanged += delegate {
-                Module._settingSkimmerBinding.Value = settingSkimmer_Keybind.KeyBinding;
-            };
 
             Label settingJackal_Label = new Label() {
                 Location = new Point(0, settingSkimmer_Label.Bottom + 6),
@@ -201,9 +193,6 @@ namespace Manlaan.Mounts.Views
                 Parent = mountsLeftPanel,
                 KeyBinding = Module._settingJackalBinding.Value,
                 Location = new Point(settingJackal_Select.Right + 5, settingJackal_Label.Top - 1),
-            };
-            settingJackal_Keybind.BindingChanged += delegate {
-                Module._settingJackalBinding.Value = settingJackal_Keybind.KeyBinding;
             };
 
             Label settingGriffon_Label = new Label() {
@@ -239,9 +228,6 @@ namespace Manlaan.Mounts.Views
                 KeyBinding = Module._settingGriffonBinding.Value,
                 Location = new Point(settingGriffon_Select.Right + 5, settingGriffon_Label.Top - 1),
             };
-            settingGriffon_Keybind.BindingChanged += delegate {
-                Module._settingGriffonBinding.Value = settingGriffon_Keybind.KeyBinding;
-            };
 
             Label settingRoller_Label = new Label() {
                 Location = new Point(0, settingGriffon_Label.Bottom + 6),
@@ -275,9 +261,6 @@ namespace Manlaan.Mounts.Views
                 Parent = mountsLeftPanel,
                 KeyBinding = Module._settingRollerBinding.Value,
                 Location = new Point(settingRoller_Select.Right + 5, settingRoller_Label.Top - 1),
-            };
-            settingRoller_Keybind.BindingChanged += delegate {
-                Module._settingRollerBinding.Value = settingRoller_Keybind.KeyBinding;
             };
 
             Label settingWarclaw_Label = new Label() {
@@ -313,11 +296,9 @@ namespace Manlaan.Mounts.Views
                 KeyBinding = Module._settingWarclawBinding.Value,
                 Location = new Point(settingWarclaw_Select.Right + 5, settingWarclaw_Label.Top - 1),
             };
-            settingWarclaw_Keybind.BindingChanged += delegate {
-                Module._settingWarclawBinding.Value = settingWarclaw_Keybind.KeyBinding;
-            };
 
-            Label settingSkyscale_Label = new Label() {
+            Label settingSkyscale_Label = new Label()
+            {
                 Location = new Point(0, settingWarclaw_Label.Bottom + 6),
                 Width = labelWidth,
                 AutoSizeHeight = false,
@@ -325,12 +306,14 @@ namespace Manlaan.Mounts.Views
                 Parent = mountsLeftPanel,
                 Text = "Skyscale: ",
             };
-            Dropdown settingSkyscale_Select = new Dropdown() {
+            Dropdown settingSkyscale_Select = new Dropdown()
+            {
                 Location = new Point(settingSkyscale_Label.Right + 5, settingSkyscale_Label.Top - 4),
                 Width = orderWidth,
                 Parent = mountsLeftPanel,
             };
-            foreach (int i in Module._mountOrder) {
+            foreach (int i in Module._mountOrder)
+            {
                 if (i == 0)
                     settingSkyscale_Select.Items.Add("Disabled");
                 else
@@ -343,16 +326,49 @@ namespace Manlaan.Mounts.Views
                 else
                     Module._settingSkyscaleOrder.Value = int.Parse(settingSkyscale_Select.SelectedItem);
             };
-            KeybindingAssigner settingSkyscale_Keybind = new KeybindingAssigner() {
+            KeybindingAssigner settingSkyscale_Keybind = new KeybindingAssigner()
+            {
                 NameWidth = 0,
                 Size = new Point(bindingWidth, 20),
                 Parent = mountsLeftPanel,
                 KeyBinding = Module._settingSkyscaleBinding.Value,
                 Location = new Point(settingSkyscale_Select.Right + 5, settingSkyscale_Label.Top - 1),
             };
-            settingSkyscale_Keybind.BindingChanged += delegate {
-                Module._settingSkyscaleBinding.Value = settingSkyscale_Keybind.KeyBinding;
+
+            Label settingDefaultMount_Label = new Label()
+            {
+                Location = new Point(0, settingSkyscale_Label.Bottom + 6),
+                Width = labelWidth,
+                AutoSizeHeight = false,
+                WrapText = false,
+                Parent = mountsLeftPanel,
+                Text = "Default mount: ",
             };
+            Dropdown settingDefaultMount_Select = new Dropdown()
+            {
+                Location = new Point(settingDefaultMount_Label.Right + 5, settingDefaultMount_Label.Top - 4),
+                Width = orderWidth,
+                Parent = mountsLeftPanel,
+            };
+            foreach (string i in Module._defaultMountChoices)
+            {
+                settingDefaultMount_Select.Items.Add(i.ToString());
+            }
+            settingDefaultMount_Select.SelectedItem = Array.Exists(Module._defaultMountChoices, e => e == Module._settingDefaultMountChoice.Value) ? Module._settingDefaultMountChoice.Value : "Disabled";
+            settingDefaultMount_Select.ValueChanged += delegate {
+                Module._settingDefaultMountChoice.Value = settingDefaultMount_Select.SelectedItem;
+            };
+            KeybindingAssigner settingDefaultMount_Keybind = new KeybindingAssigner()
+            {
+                NameWidth = 0,
+                Size = new Point(bindingWidth, 20),
+                Parent = mountsLeftPanel,
+                KeyBinding = Module._settingDefaultMountBinding.Value,
+                Location = new Point(settingDefaultMount_Select.Right + 5, settingDefaultMount_Label.Top - 1),
+            };
+
+
+
 
             #endregion
 


### PR DESCRIPTION
main features:
- added default mount action and keybinding
  - takes warclaw in wvw (although this is limited by default ingame)
  - takes skimmer when underwater or close to water
  - takes default setting otherwise
- added input queuing in combat:
  - currently not behind an option, can be added if needed 
  - postpones mount action till out of combat


small cleanups:
- added null ref in for _mountPanel in Module.cs, I got a null ref when starting it up the first time.
- in SettingsView settingRaptor_Keybind.BindingChanged += etc were not useful since the value is already updated.
  - I can be wrong about all this. 
  - I think this is because Keybind is passed in as ref to the setting.