### PR TITLE
Fix/texture loading and maybe drawing

### DIFF
--- a/Controls/DrawRadial.cs
+++ b/Controls/DrawRadial.cs
@@ -15,14 +15,14 @@ namespace Manlaan.Mounts.Controls
         public double AngleBegin { get; set; }
         public double AngleEnd { get; set; }
         public Mount Mount { get; set; }
-        public Texture Texture { get; set; }
+        public Texture2D Texture { get; set; }
         public int ImageX { get; set; }
         public int ImageY { get; set; }
         public bool Selected { get; set; }
         public bool Default { get; internal set; }
     }
 
-    internal class DrawRadial : Container
+    internal class DrawRadial : Control
     {
         private readonly Helper _helper;
         private List<RadialMount> RadialMounts = new List<RadialMount>();
@@ -46,12 +46,7 @@ namespace Manlaan.Mounts.Controls
             return CaptureType.Mouse;
         }
 
-        public override void UpdateContainer(GameTime gameTime)
-        {
-        }
-
-        public override void PaintBeforeChildren(SpriteBatch spriteBatch, Rectangle bounds)
-        {
+        protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds) {
             RadialMounts.Clear();
             var mounts = Module._availableOrderedMounts;
 
@@ -100,7 +95,6 @@ namespace Manlaan.Mounts.Controls
                 currentAngle = angleEnd;
             }
 
-
             var mousePos = Input.Mouse.Position;
             var diff = mousePos - SpawnPoint;
             var angle = Math.Atan2(diff.Y, diff.X);
@@ -111,29 +105,18 @@ namespace Manlaan.Mounts.Controls
 
             var length = new Vector2(diff.Y, diff.X).Length();
             
-            Children.Clear();
             foreach (var radialMount in RadialMounts)
             {
-                Image _btnMount = new Image
-                {
-                    Parent = this,
-                    Texture = (Blish_HUD.Content.AsyncTexture2D)radialMount.Texture,
-                    Size = new Point(mountIconSize, mountIconSize),
-                    Location = new Point(radialMount.ImageX, radialMount.ImageY),
-                    BasicTooltipText = radialMount.Mount.DisplayName
-                };
-
-                if(length < mountIconSize*Math.Sqrt(2)/2)
+                if (length < mountIconSize * Math.Sqrt(2) / 2)
                 {
                     radialMount.Selected = radialMount.Default;
-                }
-                else
+                } 
+                else 
                 {
                     radialMount.Selected = radialMount.AngleBegin <= angle && radialMount.AngleEnd > angle;
                 }
 
-                _btnMount.Opacity = radialMount.Selected ? 1f : Module._settingMountRadialIconOpacity.Value;
-                AddChild(_btnMount);
+                spriteBatch.DrawOnCtrl(this, radialMount.Texture, new Rectangle(radialMount.ImageX, radialMount.ImageY, mountIconSize, mountIconSize), null, Color.White * (radialMount.Selected ? 1f : Module._settingMountRadialIconOpacity.Value));
             }
         }
 

--- a/Helper.cs
+++ b/Helper.cs
@@ -2,6 +2,7 @@
 using Blish_HUD.Modules.Managers;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Manlaan.Mounts
@@ -9,6 +10,8 @@ namespace Manlaan.Mounts
     internal class Helper
     {
         private readonly ContentsManager contentsManager;
+
+        private readonly Dictionary<string, Texture2D> _textureCache = new Dictionary<string, Texture2D>();
 
         public Helper(ContentsManager contentsManager)
         {
@@ -28,18 +31,27 @@ namespace Manlaan.Mounts
 
         public Texture2D GetImgFile(string filename)
         {
+            string textureName = filename;
+
             switch (Module._settingDisplay.Value)
             {
                 default:
                 case "Solid":
-                    return contentsManager.GetTexture(filename + ".png");
-
+                    textureName += ".png";
+                    break;
                 case "Transparent":
-                    return contentsManager.GetTexture(filename + "-trans.png");
-
+                    textureName += "-trans.png";
+                    break;
                 case "SolidText":
-                    return contentsManager.GetTexture(filename + "-text.png");
+                    textureName += "-text.png";
+                    break;
             }
+
+            if (!_textureCache.ContainsKey(textureName)) {
+                _textureCache[textureName] = contentsManager.GetTexture(textureName);
+            }
+
+            return _textureCache[textureName];
         }
 
         private bool IsPlayerInWvWMap()

--- a/Views/SettingsView.cs
+++ b/Views/SettingsView.cs
@@ -10,9 +10,10 @@ namespace Manlaan.Mounts.Views
     class SettingsView : View
     {
         protected override void Build(Container buildPanel) {
-            int labelWidth = 100;
-            int orderWidth = 80;
-            int bindingWidth = 150;
+            int labelWidth                = 100;
+            int orderWidth                = 80;
+            int bindingWidth              = 150;
+            int mountsAndRadialInputWidth = 125;
 
             Panel mountsLeftPanel = new Panel() {
                 CanScroll = false,
@@ -125,8 +126,8 @@ namespace Manlaan.Mounts.Views
             Dropdown settingDefaultMount_Select = new Dropdown()
             {
                 Location = new Point(settingDefaultMount_Label.Right + 5, settingDefaultMount_Label.Top - 4),
-                Width = orderWidth,
-                Parent = mountsLeftPanel,
+                Width    = mountsAndRadialInputWidth,
+                Parent   = mountsLeftPanel,
             };
             settingDefaultMount_Select.Items.Add("Disabled");
             var mountNames = Module._mounts.Select(m => m.Name);
@@ -150,8 +151,8 @@ namespace Manlaan.Mounts.Views
             Dropdown settingDefaultWaterMount_Select = new Dropdown()
             {
                 Location = new Point(settingDefaultWaterMount_Label.Right + 5, settingDefaultWaterMount_Label.Top - 4),
-                Width = orderWidth,
-                Parent = mountsLeftPanel,
+                Width    = mountsAndRadialInputWidth,
+                Parent   = mountsLeftPanel,
             };
             settingDefaultWaterMount_Select.Items.Add("Disabled");
             var mountNamesWater = Module._mounts.Where(m => m.IsWaterMount).Select(m => m.Name);
@@ -174,11 +175,11 @@ namespace Manlaan.Mounts.Views
             };
             KeybindingAssigner settingDefaultMount_Keybind = new KeybindingAssigner()
             {
-                NameWidth = 0,
-                Size = new Point(labelWidth2, 20),
-                Parent = mountsLeftPanel,
+                NameWidth  = 0,
+                Size       = new Point(mountsAndRadialInputWidth, 20),
+                Parent     = mountsLeftPanel,
                 KeyBinding = Module._settingDefaultMountBinding.Value,
-                Location = new Point(settingDefaultMountKeybind_Label.Right + 5, settingDefaultMountKeybind_Label.Top - 1),
+                Location   = new Point(settingDefaultMountKeybind_Label.Right + 4, settingDefaultMountKeybind_Label.Top - 1),
             };
             Label settingDefaultMountBehaviour_Label = new Label()
             {
@@ -192,8 +193,8 @@ namespace Manlaan.Mounts.Views
             Dropdown settingDefaultMountBehaviour_Select = new Dropdown()
             {
                 Location = new Point(settingDefaultMountBehaviour_Label.Right + 5, settingDefaultMountBehaviour_Label.Top - 4),
-                Width = orderWidth,
-                Parent = mountsLeftPanel,
+                Width    = settingDefaultMount_Keybind.Width,
+                Parent   = mountsLeftPanel,
             };
             settingDefaultMountBehaviour_Select.Items.Add("Disabled");
             List<string> mountBehaviours = Module._mountBehaviour.ToList();
@@ -266,11 +267,11 @@ namespace Manlaan.Mounts.Views
             TrackBar settingMountRadialRadiusModifier_Slider = new TrackBar()
             {
                 Location = new Point(settingMountRadialRadiusModifier_Label.Right + 5, settingMountRadialRadiusModifier_Label.Top),
-                Width = 120,
+                Width    = mountsAndRadialInputWidth,
                 MaxValue = 100,
                 MinValue = 20,
-                Value = Module._settingMountRadialRadiusModifier.Value * 100,
-                Parent = mountsLeftPanel,
+                Value    = Module._settingMountRadialRadiusModifier.Value * 100,
+                Parent   = mountsLeftPanel,
             };
             settingMountRadialRadiusModifier_Slider.ValueChanged += delegate { Module._settingMountRadialRadiusModifier.Value = settingMountRadialRadiusModifier_Slider.Value / 100; };
             Label settingMountRadialIconSizeModifier_Label = new Label()
@@ -285,11 +286,11 @@ namespace Manlaan.Mounts.Views
             TrackBar settingMountRadialIconSizeModifier_Slider = new TrackBar()
             {
                 Location = new Point(settingMountRadialIconSizeModifier_Label.Right + 5, settingMountRadialIconSizeModifier_Label.Top),
-                Width = 120,
+                Width    = mountsAndRadialInputWidth,
                 MaxValue = 100,
                 MinValue = 5,
-                Value = Module._settingMountRadialIconSizeModifier.Value * 100,
-                Parent = mountsLeftPanel,
+                Value    = Module._settingMountRadialIconSizeModifier.Value * 100,
+                Parent   = mountsLeftPanel,
             };
             settingMountRadialIconSizeModifier_Slider.ValueChanged += delegate { Module._settingMountRadialIconSizeModifier.Value = settingMountRadialIconSizeModifier_Slider.Value / 100; };
         Label settingMountRadialIconOpacity_Label = new Label()
@@ -304,11 +305,11 @@ namespace Manlaan.Mounts.Views
             TrackBar settingMountRadialIconOpacity_Slider = new TrackBar()
             {
                 Location = new Point(settingMountRadialIconOpacity_Label.Right + 5, settingMountRadialIconOpacity_Label.Top),
-                Width = 120,
+                Width    = mountsAndRadialInputWidth,
                 MaxValue = 100,
                 MinValue = 5,
-                Value = Module._settingMountRadialIconOpacity.Value * 100,
-                Parent = mountsLeftPanel,
+                Value    = Module._settingMountRadialIconOpacity.Value * 100,
+                Parent   = mountsLeftPanel,
             };
             settingMountRadialIconOpacity_Slider.ValueChanged += delegate { Module._settingMountRadialIconOpacity.Value = settingMountRadialIconOpacity_Slider.Value / 100; };
             Label settingMountRadialCenterMountBehavior_Label = new Label()
@@ -323,8 +324,8 @@ namespace Manlaan.Mounts.Views
             Dropdown settingMountRadialCenterMountBehavior_Select = new Dropdown()
             {
                 Location = new Point(settingMountRadialCenterMountBehavior_Label.Right + 5, settingMountRadialCenterMountBehavior_Label.Top - 4),
-                Width = orderWidth,
-                Parent = mountsLeftPanel,
+                Width    = mountsAndRadialInputWidth,
+                Parent   = mountsLeftPanel,
             };
             foreach (string i in Module._mountRadialCenterMountBehavior)
             {


### PR DESCRIPTION
- Removes a memory leak by caching textures on load.
- Draws mount icons directly instead of relying on more controls nested within a container.
- Adjusts the width of some of the settings to make them line up better and not get cropped by their panel container.