### PR TITLE
Feature/feedback community 2

### DIFF
--- a/Controls/DrawRadial.cs
+++ b/Controls/DrawRadial.cs
@@ -119,7 +119,7 @@ namespace Manlaan.Mounts.Controls
 
         public async Task TriggerSelectedMountAsync()
         {
-            await (SelectedMount?.Mount.DoHotKey() ?? Task.CompletedTask);
+            await (SelectedMount?.Mount.DoMountAction() ?? Task.CompletedTask);
         }
 
 

--- a/Helper.cs
+++ b/Helper.cs
@@ -17,6 +17,7 @@ namespace Manlaan.Mounts
         private readonly ContentsManager contentsManager;
 
         private readonly Dictionary<string, Texture2D> _textureCache = new Dictionary<string, Texture2D>();
+        private static readonly Logger Logger = Logger.GetLogger<Helper>();
 
         public Helper(ContentsManager contentsManager)
         {
@@ -109,8 +110,10 @@ namespace Manlaan.Mounts
 
         public async Task TriggerKeybind(SettingEntry<KeyBinding> keybindingSetting)
         {
+            Logger.Debug("TriggerKeybind entered");
             if (keybindingSetting.Value.ModifierKeys != ModifierKeys.None)
             {
+                Logger.Debug($"TriggerKeybind press modfiers {keybindingSetting.Value.ModifierKeys}");
                 if (keybindingSetting.Value.ModifierKeys.HasFlag(ModifierKeys.Alt))
                     Blish_HUD.Controls.Intern.Keyboard.Press(VirtualKeyShort.MENU, true);
                 if (keybindingSetting.Value.ModifierKeys.HasFlag(ModifierKeys.Ctrl))
@@ -118,11 +121,14 @@ namespace Manlaan.Mounts
                 if (keybindingSetting.Value.ModifierKeys.HasFlag(ModifierKeys.Shift))
                     Blish_HUD.Controls.Intern.Keyboard.Press(VirtualKeyShort.SHIFT, true);
             }
+            Logger.Debug($"TriggerKeybind press PrimaryKey {keybindingSetting.Value.PrimaryKey}");
             Blish_HUD.Controls.Intern.Keyboard.Press(ToVirtualKey(keybindingSetting.Value.PrimaryKey), true);
             await Task.Delay(50);
+            Logger.Debug($"TriggerKeybind release modfiers {keybindingSetting.Value.ModifierKeys}");
             Blish_HUD.Controls.Intern.Keyboard.Release(ToVirtualKey(keybindingSetting.Value.PrimaryKey), true);
             if (keybindingSetting.Value.ModifierKeys != ModifierKeys.None)
             {
+                Logger.Debug($"TriggerKeybind release modfiers {keybindingSetting.Value.ModifierKeys}");
                 if (keybindingSetting.Value.ModifierKeys.HasFlag(ModifierKeys.Shift))
                     Blish_HUD.Controls.Intern.Keyboard.Release(VirtualKeyShort.SHIFT, true);
                 if (keybindingSetting.Value.ModifierKeys.HasFlag(ModifierKeys.Ctrl))

--- a/Helper.cs
+++ b/Helper.cs
@@ -133,7 +133,7 @@ namespace Manlaan.Mounts
                 }
                 Logger.Debug($"TriggerKeybind press PrimaryKey {keybindingSetting.Value.PrimaryKey}");
                 Blish_HUD.Controls.Intern.Keyboard.Press(ToVirtualKey(keybindingSetting.Value.PrimaryKey), true);
-                await Task.Delay(100);
+                await Task.Delay(50);
                 Logger.Debug($"TriggerKeybind release PrimaryKey {keybindingSetting.Value.PrimaryKey}");
                 Blish_HUD.Controls.Intern.Keyboard.Release(ToVirtualKey(keybindingSetting.Value.PrimaryKey), true);
                 if (keybindingSetting.Value.ModifierKeys != ModifierKeys.None)

--- a/Module.cs
+++ b/Module.cs
@@ -312,7 +312,7 @@ namespace Manlaan.Mounts
                     Opacity = _settingOpacity.Value,
                     BasicTooltipText = mount.DisplayName
                 };
-                _btnMount.LeftMouseButtonPressed += async delegate { await mount.DoHotKey(); };
+                _btnMount.LeftMouseButtonPressed += async delegate { await mount.DoMountAction(); };
 
                 if (_settingOrientation.Value.Equals("Horizontal"))
                     curX += _settingImgWidth.Value;
@@ -390,7 +390,7 @@ namespace Manlaan.Mounts
             Logger.Debug("DoDefaultMountActionAsync entered");
             if (GameService.Gw2Mumble.PlayerCharacter.CurrentMount != MountType.None)
             {
-                await (_availableOrderedMounts.FirstOrDefault()?.DoHotKey() ?? Task.CompletedTask);
+                await (_availableOrderedMounts.FirstOrDefault()?.DoUnmountAction() ?? Task.CompletedTask);
                 Logger.Debug("DoDefaultMountActionAsync dismounted");
                 return;
             }
@@ -398,7 +398,7 @@ namespace Manlaan.Mounts
             var instantMount = _helper.GetInstantMount();
             if (instantMount != null)
             {
-                await instantMount.DoHotKey();
+                await instantMount.DoMountAction();
                 Logger.Debug("DoDefaultMountActionAsync instantmount");
                 return;
             }
@@ -406,7 +406,7 @@ namespace Manlaan.Mounts
             var defaultMount = _helper.GetDefaultMount();
             if (defaultMount != null && GameService.Input.Mouse.CameraDragging)
             {
-                await (defaultMount?.DoHotKey() ?? Task.CompletedTask);
+                await (defaultMount?.DoMountAction() ?? Task.CompletedTask);
                 Logger.Debug("DoDefaultMountActionAsync CameraDragging defaultmount");
                 return;
             }
@@ -414,7 +414,7 @@ namespace Manlaan.Mounts
             switch (_settingDefaultMountBehaviour.Value)
             {
                 case "DefaultMount":
-                    await (defaultMount?.DoHotKey() ?? Task.CompletedTask);
+                    await (defaultMount?.DoMountAction() ?? Task.CompletedTask);
                     Logger.Debug("DoDefaultMountActionAsync DefaultMountBehaviour defaultmount");
                     break;
                 case "Radial":
@@ -429,7 +429,7 @@ namespace Manlaan.Mounts
         {
             if (!e.Value)
             {
-                await (_mounts.Where(m => m.QueuedTimestamp != null).OrderByDescending(m => m.QueuedTimestamp).FirstOrDefault()?.DoHotKey() ?? Task.CompletedTask);
+                await (_mounts.Where(m => m.QueuedTimestamp != null).OrderByDescending(m => m.QueuedTimestamp).FirstOrDefault()?.DoMountAction() ?? Task.CompletedTask);
                 foreach (var mount in _mounts)
                 {
                     mount.QueuedTimestamp = null;

--- a/Module.cs
+++ b/Module.cs
@@ -135,7 +135,6 @@ namespace Manlaan.Mounts
             _settingMountBlockKeybindFromGame = settings.DefineSetting("MountBlockKeybindFromGame", false, () => Strings.Setting_MountBlockKeybindFromGame, () => "");
             _settingDefaultMountBinding = settings.DefineSetting("DefaultMountBinding", new KeyBinding(Keys.None), () => Strings.Setting_DefaultMountBinding, () => "");
             _settingDefaultMountBinding.Value.Enabled = true;
-            _settingDefaultMountBinding.Value.BlockSequenceFromGw2 = true; //_settingMountBlockKeybindFromGame.Value; https://github.com/blish-hud/Blish-HUD/issues/617
             _settingDefaultMountBinding.Value.Activated += async delegate { await DoDefaultMountActionAsync(); };
             _settingDefaultMountChoice = settings.DefineSetting("DefaultMountChoice", "Disabled", () => Strings.Setting_DefaultMountChoice, () => "");
             _settingDefaultWaterMountChoice = settings.DefineSetting("DefaultWaterMountChoice", "Disabled", () => Strings.Setting_DefaultWaterMountChoice, () => "");

--- a/Module.cs
+++ b/Module.cs
@@ -43,7 +43,6 @@ namespace Manlaan.Mounts
 
         public static SettingEntry<string> _settingDefaultMountChoice;
         public static SettingEntry<string> _settingDefaultWaterMountChoice;
-        public static SettingEntry<bool> _settingMountBlockKeybindFromGame;
         public static SettingEntry<KeyBinding> _settingDefaultMountBinding;
         public static SettingEntry<bool> _settingDisplayMountQueueing;
         public static SettingEntry<string> _settingDefaultMountBehaviour;
@@ -132,7 +131,6 @@ namespace Manlaan.Mounts
                 new SiegeTurtle(settings, _helper)
             };
 
-            _settingMountBlockKeybindFromGame = settings.DefineSetting("MountBlockKeybindFromGame", false, () => Strings.Setting_MountBlockKeybindFromGame, () => "");
             _settingDefaultMountBinding = settings.DefineSetting("DefaultMountBinding", new KeyBinding(Keys.None), () => Strings.Setting_DefaultMountBinding, () => "");
             _settingDefaultMountBinding.Value.Enabled = true;
             _settingDefaultMountBinding.Value.Activated += async delegate { await DoDefaultMountActionAsync(); };
@@ -384,6 +382,11 @@ namespace Manlaan.Mounts
 
         private async Task DoDefaultMountActionAsync()
         {
+            if (_helper.IsKeybindBeingTriggered())
+            {
+                Logger.Debug("DoDefaultMountActionAsync IsKeybindBeingTriggered");
+                return;
+            }
             Logger.Debug("DoDefaultMountActionAsync entered");
             if (GameService.Gw2Mumble.PlayerCharacter.CurrentMount != MountType.None)
             {

--- a/Module.cs
+++ b/Module.cs
@@ -403,15 +403,23 @@ namespace Manlaan.Mounts
                 return;
             }
 
+            var defaultMount = _helper.GetDefaultMount();
+            if (defaultMount != null && GameService.Input.Mouse.CameraDragging)
+            {
+                await (defaultMount?.DoHotKey() ?? Task.CompletedTask);
+                Logger.Debug("DoDefaultMountActionAsync CameraDragging defaultmount");
+                return;
+            }
+
             switch (_settingDefaultMountBehaviour.Value)
             {
                 case "DefaultMount":
-                    await (_helper.GetDefaultMount()?.DoHotKey() ?? Task.CompletedTask);
-                    Logger.Debug("DoDefaultMountActionAsync defaultmount");
+                    await (defaultMount?.DoHotKey() ?? Task.CompletedTask);
+                    Logger.Debug("DoDefaultMountActionAsync DefaultMountBehaviour defaultmount");
                     break;
                 case "Radial":
                     _radial.Show();
-                    Logger.Debug("DoDefaultMountActionAsync radial");
+                    Logger.Debug("DoDefaultMountActionAsync DefaultMountBehaviour radial");
                     break;
             }
             return;

--- a/Mounts/Mount.cs
+++ b/Mounts/Mount.cs
@@ -43,7 +43,12 @@ namespace Manlaan.Mounts
         public bool IsAvailable => OrderSetting.Value != 0 && IsKeybindSet;
         public bool IsKeybindSet => KeybindingSetting.Value.ModifierKeys != ModifierKeys.None || KeybindingSetting.Value.PrimaryKey != Keys.None;
 
-        public async Task DoHotKey()
+        public async Task DoUnmountAction()
+        {
+            await _helper.TriggerKeybind(KeybindingSetting);
+        }
+
+        public async Task DoMountAction()
         {
             if (GameService.Gw2Mumble.PlayerCharacter.IsInCombat)
             {
@@ -69,7 +74,7 @@ namespace Manlaan.Mounts
                 HoverIcon = img,
                 Priority = 10
             };
-            CornerIcon.Click += async delegate { await DoHotKey(); };
+            CornerIcon.Click += async delegate { await DoMountAction(); };
         }
 
         public void DisposeCornerIcon()

--- a/Views/SettingsView.cs
+++ b/Views/SettingsView.cs
@@ -384,26 +384,6 @@ namespace Manlaan.Mounts.Views
                 Parent = defaultMountPanel,
                 Location = new Point(settingDefaultMountKeybind_Label.Right + 4, settingDefaultMountKeybind_Label.Top - 1),
             };
-            //Label settingMountBlockKeybindFromGame_Label = new Label()
-            //{
-            //    Location = new Point(0, settingDefaultMountKeybind_Label.Bottom + 6),
-            //    Width = labelWidth2,
-            //    AutoSizeHeight = false,
-            //    WrapText = false,
-            //    Parent = defaultMountPanel,
-            //    Text = "Do not send keybind to game:"
-            //};
-            //Checkbox settingMountBlockKeybindFromGame_Checkbox = new Checkbox()
-            //{
-            //    Size = new Point(labelWidth2, 20),
-            //    Parent = defaultMountPanel,
-            //    Checked = Module._settingMountBlockKeybindFromGame.Value,
-            //    Location = new Point(settingMountBlockKeybindFromGame_Label.Right + 5, settingMountBlockKeybindFromGame_Label.Top - 1),
-            //};
-            //settingMountBlockKeybindFromGame_Checkbox.CheckedChanged += delegate {
-            //    Module._settingMountBlockKeybindFromGame.Value = settingMountBlockKeybindFromGame_Checkbox.Checked;
-            //    Module._settingDefaultMountBinding.Value.BlockSequenceFromGw2 = settingMountBlockKeybindFromGame_Checkbox.Checked;
-            //};
             Label settingDefaultMountBehaviour_Label = new Label()
             {
                 Location = new Point(0, settingDefaultMountKeybind_Label.Bottom + 6),

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Mounts",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "namespace": "Manlaan.Mounts",
   "package": "Mounts.dll",
   "manifest_version": 1,
@@ -23,6 +23,9 @@
 }
 /*
     "changelog": {
+        "1.2.14": "2022-03-04:
+                  don't queue unmounting when in combat
+                  ",
         "1.2.13": "2022-03-03:
                   undo BlockSequenceFromGw2 to make sure keybinds with only a primary key still go to chat
                   don't show radial when dragging the camera with the mouse, but use defaultMount if it is configured

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Mounts",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "namespace": "Manlaan.Mounts",
   "package": "Mounts.dll",
   "manifest_version": 1,
@@ -23,6 +23,7 @@
 }
 /*
     "changelog": {
+        "1.2.15": "2022-03-13:stable release",
         "1.2.14": "2022-03-04:
                   don't queue unmounting when in combat
                   ",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Mounts",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "namespace": "Manlaan.Mounts",
   "package": "Mounts.dll",
   "manifest_version": 1,
@@ -23,6 +23,10 @@
 }
 /*
     "changelog": {
+        "1.2.13": "2022-03-03:
+                  undo BlockSequenceFromGw2 to make sure keybinds with only a primary key still go to chat
+                  don't show radial when dragging the camera with the mouse, but use defaultMount if it is configured
+                  ",
         "1.2.12": "2022-02-27:stable release",
         "1.2.11": "2022-02-27:
                   fix keybind not being enabled


### PR DESCRIPTION
don't queue unmounting when in combat
undo BlockSequenceFromGw2 to make sure keybinds with only a primary key still go to chat
don't show radial when dragging the camera with the mouse, but use defaultMount if it is configured