### PR TITLE
Feature/swap mounts

### DIFF
--- a/Controls/DrawIcons.cs
+++ b/Controls/DrawIcons.cs
@@ -88,7 +88,7 @@ namespace Manlaan.Mounts.Controls
                     Opacity = _iconThingSettings.Opacity.Value,
                     BasicTooltipText = thing.DisplayName
                 };
-                _btnMount.LeftMouseButtonPressed += async delegate { await thing.DoAction(false, true); };
+                _btnMount.LeftMouseButtonPressed += async delegate { await thing.DoAction(false, false, true); };
 
                 if (_iconThingSettings.Orientation.Value == IconOrientation.Horizontal)
                     curX += _iconThingSettings.Size.Value;

--- a/Controls/DrawRadial.cs
+++ b/Controls/DrawRadial.cs
@@ -266,27 +266,7 @@ namespace Manlaan.Mounts.Controls
                 attemptSwapMountsIfMounted = ((ContextualRadialThingSettings)SelectedSettings).AttemptSwapMountsIfMounted.Value;
             }
 
-            if (attemptSwapMountsIfMounted && 
-                _helper.IsPlayerMounted() && 
-                SelectedMount.Thing is Mount &&
-                !SelectedMount.Thing.IsInUse())
-            {
-                await SelectedMount.Thing.DoAction(unconditionallyDoAction, true);
-
-                if (SelectedMount.Thing.IsUsableInAir())
-                {
-                    await SelectedMount.Thing.DoAction(unconditionallyDoAction, true);
-                }
-                else
-                {
-                    SelectedMount.Thing.QueueAfterFalling();
-                }
-            }
-            else
-            {
-                await SelectedMount.Thing.DoAction(unconditionallyDoAction, true);
-            }
-            
+            await SelectedMount.Thing.DoAction(unconditionallyDoAction, attemptSwapMountsIfMounted, true);            
             SelectedSettings = null;
         }
 

--- a/Controls/DrawRadial.cs
+++ b/Controls/DrawRadial.cs
@@ -266,7 +266,10 @@ namespace Manlaan.Mounts.Controls
                 attemptSwapMountsIfMounted = ((ContextualRadialThingSettings)SelectedSettings).AttemptSwapMountsIfMounted.Value;
             }
 
-            if (attemptSwapMountsIfMounted && _helper.IsPlayerMounted() && SelectedMount.Thing is Mount)
+            if (attemptSwapMountsIfMounted && 
+                _helper.IsPlayerMounted() && 
+                SelectedMount.Thing is Mount &&
+                !SelectedMount.Thing.IsInUse())
             {
                 await SelectedMount.Thing.DoAction(unconditionallyDoAction, true);
 

--- a/Helper.cs
+++ b/Helper.cs
@@ -288,11 +288,6 @@ namespace Manlaan.Mounts
             return Module._things.Where(m => m.QueuedTimestamp != null).OrderByDescending(m => m.QueuedTimestamp).FirstOrDefault();
         }
 
-        internal Thing GetQueuedForAfterFallingThing()
-        {
-            return Module._things.Where(m => m.QueuedAfterFallingTimeStamp != null).OrderByDescending(m => m.QueuedAfterFallingTimeStamp).FirstOrDefault();
-        }
-
         internal async Task DoRangedThing()
         {
             if(StoredRangedThing != null)

--- a/Helper.cs
+++ b/Helper.cs
@@ -299,7 +299,7 @@ namespace Manlaan.Mounts
             {
                 var thing = StoredRangedThing;
                 Logger.Debug($"{nameof(DoRangedThing)} {thing?.Name}");
-                await thing?.DoAction(false, false);
+                await thing?.DoAction(false, false, false);
                 StoredRangedThing = null;
             }
         }
@@ -339,7 +339,7 @@ namespace Manlaan.Mounts
             var characterName = GameService.Gw2Mumble.PlayerCharacter.Name;
             var thing = StoredThingForLater[characterName];
             Logger.Debug($"{nameof(DoThingActionForLaterActivation)} {thing?.Name} for character: {characterName}");
-            await thing?.DoAction(false, false);
+            await thing?.DoAction(false, false , false);
             ClearSomethingStoredForLaterActivation();
         }
 

--- a/Helper.cs
+++ b/Helper.cs
@@ -288,6 +288,11 @@ namespace Manlaan.Mounts
             return Module._things.Where(m => m.QueuedTimestamp != null).OrderByDescending(m => m.QueuedTimestamp).FirstOrDefault();
         }
 
+        internal Thing GetQueuedForAfterFallingThing()
+        {
+            return Module._things.Where(m => m.QueuedAfterFallingTimeStamp != null).OrderByDescending(m => m.QueuedAfterFallingTimeStamp).FirstOrDefault();
+        }
+
         internal async Task DoRangedThing()
         {
             if(StoredRangedThing != null)

--- a/Module.cs
+++ b/Module.cs
@@ -96,7 +96,6 @@ namespace Manlaan.Mounts
         public static List<SkyLake> _skyLakes = new List<SkyLake>();
         private bool _lastIsThingSwitchable = false;
         private int _lastInUseThingsCount = 0;
-        private DateTime? _landedTimestamp = null;
 
 
         [ImportingConstructor]
@@ -559,29 +558,7 @@ namespace Manlaan.Mounts
 
         protected override void Update(GameTime gameTime)
         {
-            var wasGlidingOrFalling = _helper.IsPlayerGlidingOrFalling();
             _helper.UpdatePlayerGlidingOrFalling(gameTime);
-            var isGlidingOrFalling = _helper.IsPlayerGlidingOrFalling();
-
-            if (!isGlidingOrFalling && wasGlidingOrFalling)
-            {
-                _landedTimestamp = DateTime.UtcNow;
-            }
-            
-            if (isGlidingOrFalling)
-            {
-                _landedTimestamp = null;
-            }
-
-            // The falling indicator is unreliable so we make sure we are actually not falling for a bit
-            if (_landedTimestamp != null && DateTime.UtcNow.Subtract(_landedTimestamp.Value).TotalMilliseconds > 600)
-            {
-                _landedTimestamp = null;
-
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                this.HandleAfterFallingAsync();
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            }
 
             if (Mouse.GetState().LeftButton == ButtonState.Pressed)
             {
@@ -853,18 +830,6 @@ namespace Manlaan.Mounts
                 {
                     thing.QueuedTimestamp = null;
                 }
-            }
-        }
-
-        private async Task HandleAfterFallingAsync()
-        {
-            var thingInAir = _helper.GetQueuedForAfterFallingThing();
-
-            await (thingInAir?.DoAction(false, false, false) ?? Task.CompletedTask);
-
-            foreach (var thing in _things)
-            {
-                thing.QueuedAfterFallingTimeStamp = null;
             }
         }
     }

--- a/Module.cs
+++ b/Module.cs
@@ -96,6 +96,7 @@ namespace Manlaan.Mounts
         public static List<SkyLake> _skyLakes = new List<SkyLake>();
         private bool _lastIsThingSwitchable = false;
         private int _lastInUseThingsCount = 0;
+        private DateTime? _landedTimestamp = null;
 
 
         [ImportingConstructor]
@@ -558,9 +559,31 @@ namespace Manlaan.Mounts
 
         protected override void Update(GameTime gameTime)
         {
+            var wasGlidingOrFalling = _helper.IsPlayerGlidingOrFalling();
             _helper.UpdatePlayerGlidingOrFalling(gameTime);
+            var isGlidingOrFalling = _helper.IsPlayerGlidingOrFalling();
 
-            if(Mouse.GetState().LeftButton == ButtonState.Pressed)
+            if (!isGlidingOrFalling && wasGlidingOrFalling)
+            {
+                _landedTimestamp = DateTime.UtcNow;
+            }
+            
+            if (isGlidingOrFalling)
+            {
+                _landedTimestamp = null;
+            }
+
+            // The falling indicator is unreliable so we make sure we are actually not falling for a bit
+            if (_landedTimestamp != null && DateTime.UtcNow.Subtract(_landedTimestamp.Value).TotalMilliseconds > 600)
+            {
+                _landedTimestamp = null;
+
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                this.HandleAfterFallingAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }
+
+            if (Mouse.GetState().LeftButton == ButtonState.Pressed)
             {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 _helper.DoRangedThing();
@@ -830,6 +853,18 @@ namespace Manlaan.Mounts
                 {
                     thing.QueuedTimestamp = null;
                 }
+            }
+        }
+
+        private async Task HandleAfterFallingAsync()
+        {
+            var thingInAir = _helper.GetQueuedForAfterFallingThing();
+
+            await (thingInAir?.DoAction(false, false) ?? Task.CompletedTask);
+
+            foreach (var thing in _things)
+            {
+                thing.QueuedAfterFallingTimeStamp = null;
             }
         }
     }

--- a/Module.cs
+++ b/Module.cs
@@ -780,7 +780,7 @@ namespace Manlaan.Mounts
             {
                 if (tappedModuleKeybind == TappedModuleKeybindState.Tap)
                 {
-                    await tappedThing?.DoAction(selectedRadialSettings.UnconditionallyDoAction.Value, false);
+                    await tappedThing?.DoAction(selectedRadialSettings.UnconditionallyDoAction.Value, selectedRadialSettings.AttemptSwapMountsIfMounted.Value, false);
                     Logger.Debug($"{nameof(DoKeybindActionAsync)} not showing radial selected thing (tappedModuleKeybind): {tappedThing?.Name}");
                     tappedModuleKeybind = TappedModuleKeybindState.Unknown;
                     return;
@@ -798,7 +798,7 @@ namespace Manlaan.Mounts
 
             if (things.Count() == 1 && selectedRadialSettings.ApplyInstantlyIfSingle.Value)
             {
-                await things.FirstOrDefault()?.DoAction(selectedRadialSettings.UnconditionallyDoAction.Value, false);
+                await things.FirstOrDefault()?.DoAction(selectedRadialSettings.UnconditionallyDoAction.Value, selectedRadialSettings.AttemptSwapMountsIfMounted.Value, false);
                 Logger.Debug($"{nameof(DoKeybindActionAsync)} not showing radial selected thing (ApplyInstantlyIfSingle): {things.First().Name}");
                 return;
             }
@@ -806,7 +806,7 @@ namespace Manlaan.Mounts
             var defaultThing = selectedRadialSettings.GetDefaultThing();
             if (defaultThing != null && GameService.Input.Mouse.CameraDragging)
             {
-                await (defaultThing?.DoAction(false, false) ?? Task.CompletedTask);
+                await (defaultThing?.DoAction(false, false, false) ?? Task.CompletedTask);
                 Logger.Debug($"{nameof(DoKeybindActionAsync)} CameraDragging default");
                 return;
             }
@@ -814,7 +814,7 @@ namespace Manlaan.Mounts
             switch (_settingKeybindBehaviour.Value)
             {
                 case "Default":
-                    await (defaultThing?.DoAction(false, false) ?? Task.CompletedTask);
+                    await (defaultThing?.DoAction(false, false, false) ?? Task.CompletedTask);
                     Logger.Debug($"{nameof(DoKeybindActionAsync)} KeybindBehaviour default");
                     break;
                 case "Radial":
@@ -843,7 +843,7 @@ namespace Manlaan.Mounts
                 {
                     var thingInCombat = _helper.GetQueuedThing();
                     Logger.Debug($"{nameof(HandleCombatChangeAsync)} Applied queued for out of combat: {thingInCombat?.Name}");
-                    await (thingInCombat?.DoAction(false, false) ?? Task.CompletedTask);
+                    await (thingInCombat?.DoAction(false, false, false) ?? Task.CompletedTask);
                 }
                 else
                 {
@@ -860,7 +860,7 @@ namespace Manlaan.Mounts
         {
             var thingInAir = _helper.GetQueuedForAfterFallingThing();
 
-            await (thingInAir?.DoAction(false, false) ?? Task.CompletedTask);
+            await (thingInAir?.DoAction(false, false, false) ?? Task.CompletedTask);
 
             foreach (var thing in _things)
             {

--- a/Settings/ContextualRadialThingSettings.cs
+++ b/Settings/ContextualRadialThingSettings.cs
@@ -17,6 +17,7 @@ namespace Mounts.Settings
         public SettingEntry<bool> ApplyInstantlyIfSingle;
         public SettingEntry<string> ApplyInstantlyOnTap;
         public SettingEntry<bool> UnconditionallyDoAction;
+        public SettingEntry<bool> AttemptSwapMountsIfMounted;
 
         public bool IsDefault => Order == 99;
 
@@ -31,6 +32,7 @@ namespace Mounts.Settings
             ApplyInstantlyIfSingle = settingCollection.DefineSetting($"RadialThingSettings{_name}ApplyInstantlyIfSingle", defaultApplyInstantlyIfSingle);
             ApplyInstantlyOnTap = settingCollection.DefineSetting($"RadialThingSettings{_name}ApplyInstantlyOnTap", "Disabled");
             UnconditionallyDoAction = settingCollection.DefineSetting($"RadialThingSettings{_name}UnconditionallyDoAction", defaultUnconditionallyDoAction);
+            AttemptSwapMountsIfMounted = settingCollection.DefineSetting($"RadialThingSettings{_name}AttemptSwapMountsIfMounted", false);
         }
 
         public override SettingEntry<KeyBinding> GetKeybind()

--- a/Things/Mounts/Griffon.cs
+++ b/Things/Mounts/Griffon.cs
@@ -11,5 +11,10 @@ namespace Manlaan.Mounts.Things.Mounts
         }
 
         protected override MountType MountType => MountType.Griffon;
+
+        public override bool IsUsableInAir()
+        {
+            return true;
+        }
     }
 }

--- a/Things/Mounts/Skyscale.cs
+++ b/Things/Mounts/Skyscale.cs
@@ -16,5 +16,10 @@ namespace Manlaan.Mounts.Things.Mounts
         {
             return _helper.IsCombatLaunchUnlocked();
         }
+
+        public override bool IsUsableInAir()
+        {
+            return true;
+        }
     }
 }

--- a/Things/Thing.cs
+++ b/Things/Thing.cs
@@ -102,7 +102,6 @@ namespace Manlaan.Mounts.Things
                 else
                 {
                     QueueAfterFalling();
-                    return;
                 }
             }
 

--- a/Things/Thing.cs
+++ b/Things/Thing.cs
@@ -2,6 +2,7 @@
 using Blish_HUD.Controls;
 using Blish_HUD.Input;
 using Blish_HUD.Settings;
+using Manlaan.Mounts.Things.Mounts;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Mounts;
@@ -75,7 +76,7 @@ namespace Manlaan.Mounts.Things
                 HoverIcon = img,
                 Priority = 10
             };
-            CornerIcon.Click += async delegate { await DoAction(false, true); };
+            CornerIcon.Click += async delegate { await DoAction(false, false, true); };
         }
 
         public void DisposeCornerIcon()
@@ -83,12 +84,26 @@ namespace Manlaan.Mounts.Things
             CornerIcon?.Dispose();
         }
 
-        public async Task DoAction(bool unconditionallyDoAction, bool isActionComingFromMouseActionOnModuleUI)
+        public async Task DoAction(bool unconditionallyDoAction, bool attemptSwapMountsIfMounted, bool isActionComingFromMouseActionOnModuleUI)
         {
             if (unconditionallyDoAction)
             {
                 await _helper.TriggerKeybind(KeybindingSetting, WhichKeybindToRun.Both);
                 return;
+            }
+
+            if (attemptSwapMountsIfMounted && _helper.IsPlayerMounted() && this is Mount && !IsInUse())
+            {
+                if (IsUsableInAir())
+                {
+                    await _helper.TriggerKeybind(KeybindingSetting, WhichKeybindToRun.Both);
+                    await Task.Delay(350);
+                }
+                else
+                {
+                    QueueAfterFalling();
+                    return;
+                }
             }
 
             if (GameService.Gw2Mumble.PlayerCharacter.IsInCombat && Module._settingEnableMountQueueing.Value && !IsUsableInCombat() && !_helper.IsPlayerInWvwMap())

--- a/Things/Thing.cs
+++ b/Things/Thing.cs
@@ -51,6 +51,16 @@ namespace Manlaan.Mounts.Things
         }
         public event EventHandler<ValueChangedEventArgs> QueuedTimestampUpdated;
 
+        private DateTime? _queuedAfterFallingTimestamp;
+        public DateTime? QueuedAfterFallingTimeStamp
+        {
+            get { return _queuedAfterFallingTimestamp; }
+            internal set
+            {
+                _queuedAfterFallingTimestamp = value;
+            }
+        }
+
         public DateTime? LastUsedTimestamp { get; internal set; }
         public bool IsKeybindSet => KeybindingSetting.Value.ModifierKeys != ModifierKeys.None || KeybindingSetting.Value.PrimaryKey != Keys.None;
         public bool IsAvailable => IsKeybindSet;
@@ -146,6 +156,11 @@ namespace Manlaan.Mounts.Things
             return false;
         }
 
+        public virtual bool IsUsableInAir()
+        {
+            return false;
+        }
+
         public virtual bool IsGroundTargeted()
         {
             return false;
@@ -167,6 +182,11 @@ namespace Manlaan.Mounts.Things
             int hashCode = 657878212;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
             return hashCode;
+        }
+
+        public void QueueAfterFalling()
+        {
+            QueuedAfterFallingTimeStamp = DateTime.UtcNow;
         }
     }
 

--- a/Things/Thing.cs
+++ b/Things/Thing.cs
@@ -52,16 +52,6 @@ namespace Manlaan.Mounts.Things
         }
         public event EventHandler<ValueChangedEventArgs> QueuedTimestampUpdated;
 
-        private DateTime? _queuedAfterFallingTimestamp;
-        public DateTime? QueuedAfterFallingTimeStamp
-        {
-            get { return _queuedAfterFallingTimestamp; }
-            internal set
-            {
-                _queuedAfterFallingTimestamp = value;
-            }
-        }
-
         public DateTime? LastUsedTimestamp { get; internal set; }
         public bool IsKeybindSet => KeybindingSetting.Value.ModifierKeys != ModifierKeys.None || KeybindingSetting.Value.PrimaryKey != Keys.None;
         public bool IsAvailable => IsKeybindSet;
@@ -98,10 +88,6 @@ namespace Manlaan.Mounts.Things
                 {
                     await _helper.TriggerKeybind(KeybindingSetting, WhichKeybindToRun.Both);
                     await Task.Delay(350);
-                }
-                else
-                {
-                    QueueAfterFalling();
                 }
             }
 
@@ -196,11 +182,6 @@ namespace Manlaan.Mounts.Things
             int hashCode = 657878212;
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
             return hashCode;
-        }
-
-        public void QueueAfterFalling()
-        {
-            QueuedAfterFallingTimeStamp = DateTime.UtcNow;
         }
     }
 

--- a/Views/RadialThingSettingsView.cs
+++ b/Views/RadialThingSettingsView.cs
@@ -482,8 +482,8 @@ namespace Manlaan.Mounts.Views
                     AutoSizeHeight = false,
                     WrapText = false,
                     Parent = RadialSettingsDetailPanel,
-                    Text = "Attempt to Swap Mounts If Mounted",
-                    BasicTooltipText = "If selected will run the action twice in case the player is mounted, causing a mount swap"
+                    Text = "Attempt to Swap Mounts If Mounted (Flying only)",
+                    BasicTooltipText = "If selected will run the action twice in case the player is mounted and the target is a flying mount, causing a mount swap"
                 };
                 Checkbox radialSettingsAttemptSwapMountsIfMounted_Checkbox = new Checkbox()
                 {

--- a/Views/RadialThingSettingsView.cs
+++ b/Views/RadialThingSettingsView.cs
@@ -474,6 +474,27 @@ namespace Manlaan.Mounts.Views
                 radialSettingsUnconditionallyDoAction_Checkbox.CheckedChanged += delegate {
                     contextualRadialSettingsAtBottom.UnconditionallyDoAction.Value = radialSettingsUnconditionallyDoAction_Checkbox.Checked;
                 };
+
+                Label radialSettingsAttemptSwapMountsIfMounted_Label = new Label()
+                {
+                    Location = new Point(0, radialSettingsUnconditionallyDoAction_Label.Bottom + 6),
+                    Width = labelWidth,
+                    AutoSizeHeight = false,
+                    WrapText = false,
+                    Parent = RadialSettingsDetailPanel,
+                    Text = "Attempt to Swap Mounts If Mounted",
+                    BasicTooltipText = "If selected will run the action twice in case the player is mounted, causing a mount swap"
+                };
+                Checkbox radialSettingsAttemptSwapMountsIfMounted_Checkbox = new Checkbox()
+                {
+                    Size = new Point(20, 20),
+                    Parent = RadialSettingsDetailPanel,
+                    Checked = contextualRadialSettingsAtBottom.AttemptSwapMountsIfMounted.Value,
+                    Location = new Point(radialSettingsAttemptSwapMountsIfMounted_Label.Right + 5, radialSettingsAttemptSwapMountsIfMounted_Label.Top - 1),
+                };
+                radialSettingsAttemptSwapMountsIfMounted_Checkbox.CheckedChanged += delegate {
+                    contextualRadialSettingsAtBottom.AttemptSwapMountsIfMounted.Value = radialSettingsAttemptSwapMountsIfMounted_Checkbox.Checked;
+                };
             }
 
             ThingSettingsView thingSettingsView = new ThingSettingsView(currentRadialSettings)


### PR DESCRIPTION
Adds a radial option to swap mounts (basically run the action twice) instead of just demounting (running it once).
Mainly useful for transitioning between Skyscale and Griffon.

I added a new event for "after falling", but due to how falling is detected I had to add a delay to make sure we really landed. (can we improve that?)

* There might be a place for adding a clearing of the queued action, I wasn't sure if it was needed

P.S: Love your module and I hope you still maintain it, I figured I will open this as an official PR in case you still do. I am open for comments and suggestions :)